### PR TITLE
Added option for allowing self-signed certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ Usage
   $ wsc [options] ws://echo.websocket.org
 
 Options
-  -e, --eval            Evaluate input as JS and encode as JSON
-  -r, --roundtrip       Track roundtrip time between sent/recv
-  -t, --time            Print a timestamp in ms before each line
-  -p, --protocol <str>  Set protocol
-  -M                    Disable masking
-  -C                    Disable color output
+  -e, --eval                Evaluate input as JS and encode as JSON
+  -r, --roundtrip           Track roundtrip time between sent/recv
+  -t, --time                Print a timestamp in ms before each line
+  -p, --protocol <str>      Set protocol
+  -a, --allow-unauthorized  Allow self-signed certificates
+  -M                        Disable masking
+  -C                        Disable color output
 ```
 
 #### Installation

--- a/wsc
+++ b/wsc
@@ -9,20 +9,22 @@ const cli = parser(`
     $ wsc [options] ws://echo.websocket.org
 
   Options
-    -e, --eval            Evaluate input as JS and encode as JSON
-    -r, --roundtrip       Track roundtrip time between sent/recv
-    -t, --time            Print a timestamp in ms before each line
-    -p, --protocol <str>  Set protocol
-    -M                    Disable masking
-    -C                    Disable color output
+    -e, --eval                Evaluate input as JS and encode as JSON
+    -r, --roundtrip           Track roundtrip time between sent/recv
+    -t, --time                Print a timestamp in ms before each line
+    -p, --protocol <str>      Set protocol
+    -a, --allow-unauthorized  Allow self-signed certificates
+    -M                        Disable masking
+    -C                        Disable color output
 `, {
-  boolean: ['e', 'r', 't', 'M', 'C'],
+  boolean: ['e', 'r', 't', 'a', 'M', 'C'],
   string: ['p'],
   alias: {
     e: 'eval',
     r: 'roundtrip',
     t: 'time',
-    p: 'protocol'
+    p: 'protocol',
+    a: 'allow-unauthorized'
   }
 });
 
@@ -42,7 +44,7 @@ const rl = readline.createInterface({
 });
 
 const url = cli.input[0];
-const ws = new WebSocket(url, cli.flags.protocol);
+const ws = new WebSocket(url, cli.flags.protocol, {rejectUnauthorized: !cli.flags.allowUnauthorized});
 
 ws.on('open', () => {
   var sent = Date.now();


### PR DESCRIPTION
Currently, the attempt to connect to the WebSocket server encrypted with self-signed certificate causes an error:
```
Error: self signed certificate
```

This pull request fixes it by adding `-a` (`--allow-unauthorized`) flag.

It will be useful for testing secured WebSocket servers during the development process.