### PR TITLE
upgrade dependencies, add opt-in performance dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# npm lockfile
+/package-lock.json

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "homepage": "https://github.com/danielstjules/wsc#readme",
   "dependencies": {
-    "chalk": "^1.1.3",
-    "meow": "^3.7.0",
-    "ws": "^1.1.1"
+    "chalk": "^2.4.2",
+    "meow": "^4.0.1",
+    "ws": "^5.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,5 +32,9 @@
     "chalk": "^2.4.2",
     "meow": "^4.0.1",
     "ws": "^5.2.2"
+  },
+  "optionalDependencies": {
+    "bufferutil": "^4.0.1",
+    "utf-8-validate": "^5.0.2"
   }
 }

--- a/wsc
+++ b/wsc
@@ -16,13 +16,35 @@ const cli = parser(`
     -M                    Disable masking
     -C                    Disable color output
 `, {
-  boolean: ['e', 'r', 't', 'M', 'C'],
-  string: ['p'],
-  alias: {
-    e: 'eval',
-    r: 'roundtrip',
-    t: 'time',
-    p: 'protocol'
+  flags: {
+    eval: {
+      type: 'boolean',
+      alias: 'e',
+      default: false
+    },
+    roundtrip: {
+      type: 'boolean',
+      alias: 'r',
+      default: false
+    },
+    time: {
+      type: 'boolean',
+      alias: 't',
+      default: false
+    },
+    protocol: {
+      type: 'string',
+      alias: 'p',
+      default: null
+    },
+    M: { // disable masking
+      type: 'boolean',
+      default: false
+    },
+    C: { // disable color output
+      type: 'boolean',
+      default: false
+    }
   }
 });
 


### PR DESCRIPTION
This PR upgrades `chalk`, `meow` and `ws` to their latest versions compatible with Node `4`.